### PR TITLE
Fix types and response not resolving with the server's response

### DIFF
--- a/src/rcon.ts
+++ b/src/rcon.ts
@@ -31,7 +31,7 @@ class RCON {
      * Authenticates the connection
      * @param password Password string
      */
-    async authenticate(password: string): Promise<boolean> {
+    async authenticate(password: string): Promise<boolean | void> {
 
         if (!this.connected) {
             await this.connect()
@@ -163,7 +163,10 @@ class RCON {
                     this.connection.removeListener('data', onData)
                 } else if (id === decodedPacket.id) {
                     response = response.concat(decodedPacket.body.replace(/\n$/, '\n')) // remove last line break
-                    if (response.includes(`command "${body}"`)) {
+
+                    // Check the response if it's defined rather than if it contains 'command ${body}'
+                    // Reason for this is because we no longer need to check if it starts with 'command', testing shows it never will
+                    if (response) {
                         this.connection.removeListener('data', onData)
                         resolve(response)
                     }

--- a/src/rcon.ts
+++ b/src/rcon.ts
@@ -31,7 +31,7 @@ class RCON {
      * Authenticates the connection
      * @param password Password string
      */
-    async authenticate(password: string): Promise<boolean | void> {
+    async authenticate(password: string): Promise<void> {
 
         if (!this.connected) {
             await this.connect()

--- a/src/rcon.ts
+++ b/src/rcon.ts
@@ -31,7 +31,7 @@ class RCON {
      * Authenticates the connection
      * @param password Password string
      */
-    async authenticate(password: string): Promise<void> {
+    async authenticate(password: string): Promise<boolean> {
 
         if (!this.connected) {
             await this.connect()
@@ -47,7 +47,7 @@ class RCON {
                 .then((data) => {
                     if (data === true) {
                         this.authenticated =  true
-                        resolve()
+                        resolve(true)
                     } else {
                         this.disconnect()
                         reject(Error('Unable to authenticate'))


### PR DESCRIPTION
This PR fixes an issue  `authenticate` not building and the response never resolving the server's response.

```
//rcon.ts
 this.write(protocol.SERVERDATA_AUTH, protocol.ID_AUTH, password)
                .then((data) => {
                    if (data === true) {
                        this.authenticated =  true
                        resolve() //Returns undefined upon successful auth!
                    } else {
```
The issue with the types is that when `resolve()` was called, it would return void, which you couldn't test if it was authenticated. To fix this, we return `resolve(true)`, returning that the server was authenticated.

```
//rcon.ts
 this.write(protocol.SERVERDATA_AUTH, protocol.ID_AUTH, password)
                .then((data) => {
                    if (data === true) {
                        this.authenticated =  true
                        resolve(true) //Returns true upon successful auth
                    } else {
```


```
//rcon.ts
 response = response.concat(decodedPacket.body.replace(/\n$/, '\n')) // remove last line break
                    if (response.includes(`command "${body}"`)) { // Never returns true, the response will not have command prefixed
                        this.connection.removeListener('data', onData)
                        resolve(response)
                    }
```

The response never resolving was an issue with checking if the string `response` contained the prefixed word `command`. This is no longer the case as it seems with my testing, and just returns the raw response. To fix this, we just check if there is a response, and to go ahead with the resolving of the response.

Also, added a comment to explain why we're doing this check so it makes sense why it's being used.

```
//rcon.ts
 response = response.concat(decodedPacket.body.replace(/\n$/, '\n')) // remove last line break
                    if (response) { // Will resove if there's a response length
                        this.connection.removeListener('data', onData)
                        resolve(response)
                    }
```

I will be testing this actively as I rely on this package to do all my rcon communication, and since it'll be written in typescript, types are a must.