### PR TITLE
Convert export to default export

### DIFF
--- a/src/rcon.ts
+++ b/src/rcon.ts
@@ -202,4 +202,4 @@ interface RCONOptions {
     timeout?: number
 }
 
-export = RCON
+export default RCON


### PR DESCRIPTION
Reason for this change is because of the following:

```typescript
import Rcon from 'rcon-srcds';

// Results in TypeError: rcon_srcds_1.default is not a constructor
```

However, if we use the alternative syntax to import everything as a constant:

```typescript

import * as Rcon from 'rcon-srcds';

// Results in This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.
```

Changes:

```typescript
// Old
export = RCON

// New
export default RCON
```

With the default export, everything works as expected. 