### PR TITLE
Fix Rcon is not a constructor

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -16,3 +16,4 @@ const protocol = Object.freeze({
 })
 
 export default protocol
+module.exports = protocol

--- a/src/rcon.ts
+++ b/src/rcon.ts
@@ -209,3 +209,4 @@ interface RCONOptions {
 }
 
 export default RCON
+module.exports = RCON


### PR DESCRIPTION
Hello

This fixes https://github.com/EnriqCG/rcon-srcds/issues/13 which just broke my system (again).

I'm not very well-versed in node or modules, but I know this makes the package work as a module and prevents the above error, probably without breaking anything else, as I left the normal export default in there.